### PR TITLE
Better summary + generic modal

### DIFF
--- a/src/Grid.css
+++ b/src/Grid.css
@@ -274,3 +274,27 @@
 .button:focus {
   outline: none;
 }
+
+.emphasize-name {
+  display: inline-block;
+  border: black 2px solid;
+  border-radius: 6px;
+  padding: 4px;
+  font-weight: 600;
+  margin: 0 5px;
+}
+
+.win-conditional {
+  margin-bottom: 10px;
+}
+
+.win-cond-score {
+  padding: 4px;
+  border-radius: 5px;
+}
+
+.action-type {
+  font-weight: bold;
+  font-size: 17px;
+  margin-right: 10px;
+}

--- a/src/editGame.tsx
+++ b/src/editGame.tsx
@@ -1,7 +1,6 @@
 import React, { useCallback } from 'react';
-import { createPortal } from 'react-dom';
 import type Game from './types/game';
-import './Modal.css';
+import Modal from './modal';
 
 interface Props {
   setGameId: (gameId?: string) => void;
@@ -31,29 +30,18 @@ export default function EditGame({
     [setGameId],
   );
 
-  if (!isOpen) {
-    return null;
-  }
-
-  return createPortal(
-    <>
-      <button className="modal-background" onClick={onClose} />
-      <div className="modal-content">
-        <button onClick={onClose} className="close">
-          &times;
-        </button>
-        <form>
-          <select className="game-input" onChange={setGame} value={gameId}>
-            <option disabled>Select a game</option>
-            {games?.map(({ gameId: id, awayTeam, homeTeam }) => (
-              <option key={id} value={id}>
-                {awayTeam} {homeTeam}
-              </option>
-            ))}
-          </select>
-        </form>
-      </div>
-    </>,
-    document.body,
+  return (
+    <Modal onClose={onClose} isOpen={isOpen}>
+      <form>
+        <select className="game-input" onChange={setGame} value={gameId}>
+          <option disabled>Select a game</option>
+          {games?.map(({ gameId: id, awayTeam, homeTeam }) => (
+            <option key={id} value={id}>
+              {awayTeam} {homeTeam}
+            </option>
+          ))}
+        </select>
+      </form>
+    </Modal>
   );
 }

--- a/src/editPlayers.tsx
+++ b/src/editPlayers.tsx
@@ -1,7 +1,6 @@
 import React, { useCallback } from 'react';
-import { createPortal } from 'react-dom';
 import type Player from './types/player';
-import './Modal.css';
+import Modal from './modal';
 
 interface Props {
   setPlayers: (players: Record<string, Player>) => void;
@@ -35,32 +34,21 @@ export default function EditPlayers({
     [players, setPlayers],
   );
 
-  if (!isOpen) {
-    return null;
-  }
-
-  return createPortal(
-    <>
-      <button className="modal-background" onClick={onClose} />
-      <div className="modal-content">
-        <button onClick={onClose} className="close">
-          &times;
-        </button>
-        <form>
-          {Object.entries(players).map(([id, player]) => (
-            <input
-              type="text"
-              key={id}
-              id={id}
-              value={player.name ?? ''}
-              className="player-input"
-              style={{ backgroundColor: player.color }}
-              onChange={setPlayer}
-            />
-          ))}
-        </form>
-      </div>
-    </>,
-    document.body,
+  return (
+    <Modal isOpen={isOpen} onClose={onClose}>
+      <form>
+        {Object.entries(players).map(([id, player]) => (
+          <input
+            type="text"
+            key={id}
+            id={id}
+            value={player.name ?? ''}
+            className="player-input"
+            style={{ backgroundColor: player.color }}
+            onChange={setPlayer}
+          />
+        ))}
+      </form>
+    </Modal>
   );
 }

--- a/src/future-utils.ts
+++ b/src/future-utils.ts
@@ -1,8 +1,8 @@
 const SCORES = {
   touchdown: 7,
-  fieldgoal: 3,
-  touchdownExtra: 8,
-  touchdownMiss: 6,
+  "field goal": 3,
+  "touchdown + extra 2 points": 8,
+  "touchdown + missed kick": 6,
   safety: 2,
   /**
    * Below in comments for completeness, but we don't
@@ -12,11 +12,6 @@ const SCORES = {
   // forceTurnoverScore: 2
 };
 
-/**
- *
- * @param {number} homeScore
- * @param {number} awayScore
- */
 export function allNextScores(homeScore: number, awayScore: number) {
   const scoreOptions = Object.entries(SCORES);
   const combinations = [];
@@ -30,24 +25,19 @@ export function allNextScores(homeScore: number, awayScore: number) {
       home: homeScoreOption,
       away: awayScore,
       type: scoreType,
-      scorer: 'home',
+      scorer: "home",
     });
     combinations.push({
       home: homeScore,
       away: awayScoreOption,
       type: scoreType,
-      scorer: 'away',
+      scorer: "away",
     });
   }
 
   return combinations;
 }
 
-/**
- * @param {number} homeScore
- * @param {number} awayScore
- * @returns {string}
- */
 export function scoreToOwnerKey(homeScore: number, awayScore: number): string {
   return `${homeScore},${awayScore}`;
 }

--- a/src/future-utils.ts
+++ b/src/future-utils.ts
@@ -1,3 +1,5 @@
+import type PlayerType from "./types/player";
+
 const SCORES = {
   touchdown: 7,
   "field goal": 3,
@@ -12,7 +14,11 @@ const SCORES = {
   // forceTurnoverScore: 2
 };
 
-export function allNextScores(homeScore: number, awayScore: number) {
+export function allNextScores(
+  homeScore: number,
+  awayScore: number,
+  scoreToOwner: (homeScore: number, awayScore: number) => PlayerType
+) {
   const scoreOptions = Object.entries(SCORES);
   const combinations = [];
 
@@ -26,16 +32,20 @@ export function allNextScores(homeScore: number, awayScore: number) {
       away: awayScore,
       type: scoreType,
       scorer: "home",
+      owner: scoreToOwner(homeScoreOption, awayScore),
     });
     combinations.push({
       home: homeScore,
       away: awayScoreOption,
       type: scoreType,
       scorer: "away",
+      owner: scoreToOwner(homeScore, awayScoreOption),
     });
   }
 
-  return combinations;
+  return combinations.sort((a, b) => {
+    return (a.owner?.name ?? 0) > (b.owner?.name ?? 0) ? 1 : -1;
+  });
 }
 
 export function scoreToOwnerKey(homeScore: number, awayScore: number): string {

--- a/src/future-utils.ts
+++ b/src/future-utils.ts
@@ -1,10 +1,10 @@
-import type PlayerType from "./types/player";
+import type PlayerType from './types/player';
 
 const SCORES = {
   touchdown: 7,
-  "field goal": 3,
-  "touchdown + extra 2 points": 8,
-  "touchdown + missed kick": 6,
+  'field goal': 3,
+  'touchdown + extra 2 points': 8,
+  'touchdown + missed kick': 6,
   safety: 2,
   /**
    * Below in comments for completeness, but we don't
@@ -17,7 +17,7 @@ const SCORES = {
 export function allNextScores(
   homeScore: number,
   awayScore: number,
-  scoreToOwner: (homeScore: number, awayScore: number) => PlayerType
+  scoreToOwner: (homeScore: number, awayScore: number) => PlayerType,
 ) {
   const scoreOptions = Object.entries(SCORES);
   const combinations = [];
@@ -31,14 +31,14 @@ export function allNextScores(
       home: homeScoreOption,
       away: awayScore,
       type: scoreType,
-      scorer: "home",
+      scorer: 'home',
       owner: scoreToOwner(homeScoreOption, awayScore),
     });
     combinations.push({
       home: homeScore,
       away: awayScoreOption,
       type: scoreType,
-      scorer: "away",
+      scorer: 'away',
       owner: scoreToOwner(homeScore, awayScoreOption),
     });
   }
@@ -48,6 +48,9 @@ export function allNextScores(
   });
 }
 
-export function scoreToOwnerKey(homeScore: number, awayScore: number): string {
+export function scoreToOwnerKey(
+  homeScore: number | string,
+  awayScore: number | string,
+): string {
   return `${homeScore},${awayScore}`;
 }

--- a/src/grid.tsx
+++ b/src/grid.tsx
@@ -371,39 +371,37 @@ export default function Grid({
     [setIsSummaryOpen],
   );
 
-  function scores() {
-    return (
-      <div className="score-container">
-        <label className="score-label">
-          {awayTeam}
-          <input
-            onChange={setActualScore}
-            value={awayActualScore}
-            name="away-actual-score"
-            placeholder={awayTeam}
-            className={`score-input ${awayTeam?.toLowerCase()}`}
-            type="number"
-            min="0"
-            disabled={isAutoUpdating}
-          />
-        </label>
-        <div className="score-divider">-</div>
-        <label className="score-label">
-          {homeTeam}
-          <input
-            onChange={setActualScore}
-            value={homeActualScore}
-            name="home-actual-score"
-            placeholder={homeTeam}
-            className={`score-input ${homeTeam?.toLowerCase()}`}
-            type="number"
-            min="0"
-            disabled={isAutoUpdating}
-          />
-        </label>
-      </div>
-    );
-  }
+  const scores = (
+    <div className="score-container">
+      <label className="score-label">
+        {awayTeam}
+        <input
+          onChange={setActualScore}
+          value={awayActualScore}
+          name="away-actual-score"
+          placeholder={awayTeam}
+          className={`score-input ${awayTeam?.toLowerCase()}`}
+          type="number"
+          min="0"
+          disabled={isAutoUpdating}
+        />
+      </label>
+      <div className="score-divider">-</div>
+      <label className="score-label">
+        {homeTeam}
+        <input
+          onChange={setActualScore}
+          value={homeActualScore}
+          name="home-actual-score"
+          placeholder={homeTeam}
+          className={`score-input ${homeTeam?.toLowerCase()}`}
+          type="number"
+          min="0"
+          disabled={isAutoUpdating}
+        />
+      </label>
+    </div>
+  );
 
   return (
     <div className="container">
@@ -457,61 +455,67 @@ export default function Grid({
             games={games}
           />
           <Modal isOpen={isSummaryOpen} onClose={hideSummary}>
-            {scores()}
+            {scores}
 
-            <h2>
-              <span
-                className="emphasize-name"
-                style={{
-                  backgroundColor: scoreToOwner(
-                    homeActualScore,
-                    awayActualScore
-                  ).color,
-                }}
-              >
-                {scoreToOwner(homeActualScore, awayActualScore).name}
-              </span>{" "}
-              is leading, but...
-            </h2>
-            {allNextScores(homeActualScore, awayActualScore, scoreToOwner).map(
-              (nextScore, idx) => {
-                if (!nextScore.owner?.name) {
-                  return null;
-                }
+            {isSummaryOpen && (
+              <>
+                <h2>
+                  <span
+                    className="emphasize-name"
+                    style={{
+                      backgroundColor: scoreToOwner(
+                        homeActualScore,
+                        awayActualScore,
+                      )?.color,
+                    }}>
+                    {scoreToOwner(homeActualScore, awayActualScore).name}
+                  </span>{' '}
+                  is leading, but...
+                </h2>
+                {allNextScores(
+                  homeActualScore,
+                  awayActualScore,
+                  scoreToOwner,
+                ).map((nextScore, idx) => {
+                  if (!nextScore.owner?.name) {
+                    return null;
+                  }
 
-                const team = nextScore.scorer === 'home' ? homeTeam : awayTeam;
+                  const team =
+                    nextScore.scorer === 'home' ? homeTeam : awayTeam;
 
-                return (
-                  <div key={idx} className="win-conditional">
-                    <div
-                      className="emphasize-name"
-                      style={{ backgroundColor: nextScore.owner.color }}>
-                      {nextScore.owner.name}
+                  return (
+                    <div key={idx} className="win-conditional">
+                      <div
+                        className="emphasize-name"
+                        style={{ backgroundColor: nextScore.owner.color }}>
+                        {nextScore.owner.name}
+                      </div>
+                      wins if
+                      <div className={`emphasize-name ${team.toLowerCase()}`}>
+                        {team}
+                      </div>
+                      scores a{' '}
+                      <span className="action-type">{nextScore.type}</span>
+                      <span
+                        className={`win-cond-score ${awayTeam.toLowerCase()}`}>
+                        {nextScore.away}
+                      </span>{' '}
+                      -{' '}
+                      <span
+                        className={`win-cond-score ${homeTeam.toLowerCase()}`}>
+                        {nextScore.home}
+                      </span>
                     </div>
-                    wins if
-                    <div className={`emphasize-name ${team.toLowerCase()}`}>
-                      {team}
-                    </div>
-                    scores a{' '}
-                    <span className="action-type">{nextScore.type}</span>
-                    <span
-                      className={`win-cond-score ${awayTeam.toLowerCase()}`}>
-                      {nextScore.away}
-                    </span>{' '}
-                    -{' '}
-                    <span
-                      className={`win-cond-score ${homeTeam.toLowerCase()}`}>
-                      {nextScore.home}
-                    </span>
-                  </div>
-                );
-              },
+                  );
+                })}
+              </>
             )}
           </Modal>
         </div>
       </div>
 
-      {scores()}
+      {scores}
 
       <div className="time">
         <div className="clock">{clock}</div>

--- a/src/grid.tsx
+++ b/src/grid.tsx
@@ -371,6 +371,40 @@ export default function Grid({
     [setIsSummaryOpen],
   );
 
+  function scores() {
+    return (
+      <div className="score-container">
+        <label className="score-label">
+          {awayTeam}
+          <input
+            onChange={setActualScore}
+            value={awayActualScore}
+            name="away-actual-score"
+            placeholder={awayTeam}
+            className={`score-input ${awayTeam?.toLowerCase()}`}
+            type="number"
+            min="0"
+            disabled={isAutoUpdating}
+          />
+        </label>
+        <div className="score-divider">-</div>
+        <label className="score-label">
+          {homeTeam}
+          <input
+            onChange={setActualScore}
+            value={homeActualScore}
+            name="home-actual-score"
+            placeholder={homeTeam}
+            className={`score-input ${homeTeam?.toLowerCase()}`}
+            type="number"
+            min="0"
+            disabled={isAutoUpdating}
+          />
+        </label>
+      </div>
+    );
+  }
+
   return (
     <div className="container">
       <div className="control-container">
@@ -423,7 +457,22 @@ export default function Grid({
             games={games}
           />
           <Modal isOpen={isSummaryOpen} onClose={hideSummary}>
-            <h2>In one score...</h2>
+            {scores()}
+
+            <h2>
+              <span
+                className="emphasize-name"
+                style={{
+                  backgroundColor: scoreToOwner(
+                    homeActualScore,
+                    awayActualScore
+                  ).color,
+                }}
+              >
+                {scoreToOwner(homeActualScore, awayActualScore).name}
+              </span>{" "}
+              is leading, but...
+            </h2>
             {allNextScores(homeActualScore, awayActualScore, scoreToOwner).map(
               (nextScore, idx) => {
                 if (!nextScore.owner?.name) {
@@ -462,35 +511,7 @@ export default function Grid({
         </div>
       </div>
 
-      <div className="score-container">
-        <label className="score-label">
-          {awayTeam}
-          <input
-            onChange={setActualScore}
-            value={awayActualScore}
-            name="away-actual-score"
-            placeholder={awayTeam}
-            className={`score-input ${awayTeam?.toLowerCase()}`}
-            type="number"
-            min="0"
-            disabled={isAutoUpdating}
-          />
-        </label>
-        <div className="score-divider">-</div>
-        <label className="score-label">
-          {homeTeam}
-          <input
-            onChange={setActualScore}
-            value={homeActualScore}
-            name="home-actual-score"
-            placeholder={homeTeam}
-            className={`score-input ${homeTeam?.toLowerCase()}`}
-            type="number"
-            min="0"
-            disabled={isAutoUpdating}
-          />
-        </label>
-      </div>
+      {scores()}
 
       <div className="time">
         <div className="clock">{clock}</div>

--- a/src/grid.tsx
+++ b/src/grid.tsx
@@ -424,11 +424,9 @@ export default function Grid({
           />
           <Modal isOpen={isSummaryOpen} onClose={hideSummary}>
             <h2>In one score...</h2>
-            {allNextScores(homeActualScore, awayActualScore).map(
+            {allNextScores(homeActualScore, awayActualScore, scoreToOwner).map(
               (nextScore, idx) => {
-                const owner = scoreToOwner(nextScore.home, nextScore.away);
-
-                if (!owner?.name) {
+                if (!nextScore.owner?.name) {
                   return null;
                 }
 
@@ -438,8 +436,8 @@ export default function Grid({
                   <div key={idx} className="win-conditional">
                     <div
                       className="emphasize-name"
-                      style={{ backgroundColor: owner.color }}>
-                      {owner.name}
+                      style={{ backgroundColor: nextScore.owner.color }}>
+                      {nextScore.owner.name}
                     </div>
                     wins if
                     <div className={`emphasize-name ${team.toLowerCase()}`}>

--- a/src/modal.tsx
+++ b/src/modal.tsx
@@ -1,7 +1,6 @@
-import React, { useCallback } from "react";
-import { createPortal } from "react-dom";
-import type Player from "./types/player";
-import "./Modal.css";
+import React from 'react';
+import { createPortal } from 'react-dom';
+import './Modal.css';
 
 interface Props {
   onClose: () => void;
@@ -19,6 +18,6 @@ export default function Modal({ onClose, isOpen, children }: Props) {
       <button className="modal-background" onClick={onClose} />
       <div className="modal-content">{children}</div>
     </>,
-    document.body
+    document.body,
   );
 }

--- a/src/modal.tsx
+++ b/src/modal.tsx
@@ -1,0 +1,24 @@
+import React, { useCallback } from "react";
+import { createPortal } from "react-dom";
+import type Player from "./types/player";
+import "./Modal.css";
+
+interface Props {
+  onClose: () => void;
+  isOpen: boolean;
+  children: React.ReactNode;
+}
+
+export default function Modal({ onClose, isOpen, children }: Props) {
+  if (!isOpen) {
+    return null;
+  }
+
+  return createPortal(
+    <>
+      <button className="modal-background" onClick={onClose} />
+      <div className="modal-content">{children}</div>
+    </>,
+    document.body
+  );
+}

--- a/src/modal.tsx
+++ b/src/modal.tsx
@@ -16,7 +16,12 @@ export default function Modal({ onClose, isOpen, children }: Props) {
   return createPortal(
     <>
       <button className="modal-background" onClick={onClose} />
-      <div className="modal-content">{children}</div>
+      <div className="modal-content">
+        <button onClick={onClose} className="close">
+          &times;
+        </button>
+        {children}
+      </div>
     </>,
     document.body,
   );

--- a/src/player.tsx
+++ b/src/player.tsx
@@ -1,7 +1,6 @@
 import React, { useCallback, useMemo } from 'react';
 
 import './Player.css';
-import Square from './types/square';
 
 interface Props {
   id?: string;

--- a/src/summaryModal.tsx
+++ b/src/summaryModal.tsx
@@ -1,0 +1,114 @@
+import React, { useCallback } from 'react';
+import { allNextScores, scoreToOwnerKey } from './future-utils';
+import Modal from './modal';
+import Grid from './types/grid';
+import Players from './types/player';
+
+interface Props {
+  onClose: () => void;
+  isOpen: boolean;
+  grid: Grid;
+  homeScore: string[];
+  awayScore: string[];
+  players: Record<string, Players>;
+  homeActualScore: number;
+  awayActualScore: number;
+  homeTeam: string;
+  awayTeam: string;
+  scores?: React.ReactElement;
+}
+
+export default function SummaryModal({
+  onClose,
+  isOpen,
+  grid,
+  homeScore,
+  awayScore,
+  players,
+  homeActualScore,
+  awayActualScore,
+  awayTeam,
+  homeTeam,
+  scores,
+}: Props) {
+  const scoreToOwnerIdMap = React.useMemo(() => {
+    const updatedScoreToOwnerIdMap = Object.keys(grid).reduce(
+      (map, id) => {
+        const square = grid[id];
+
+        if (square.ownerId !== undefined) {
+          const homeScoreIndex = id[1];
+          const awayScoreIndex = id[0];
+          const scoreKey = scoreToOwnerKey(
+            homeScore[parseInt(homeScoreIndex, 10)],
+            awayScore[parseInt(awayScoreIndex, 10)],
+          );
+          map[scoreKey] = square.ownerId;
+        }
+
+        return map;
+      },
+      {} as Record<string, string>,
+    );
+
+    return updatedScoreToOwnerIdMap;
+  }, [awayScore, grid, homeScore]);
+
+  const scoreToOwner = useCallback(
+    (homeScore: number, awayScore: number) =>
+      players[scoreToOwnerIdMap[scoreToOwnerKey(homeScore, awayScore)]],
+    [players, scoreToOwnerIdMap],
+  );
+
+  return (
+    <Modal onClose={onClose} isOpen={isOpen}>
+      {isOpen && (
+        <>
+          {scores}
+          <h2>
+            <span
+              className="emphasize-name"
+              style={{
+                backgroundColor: scoreToOwner(homeActualScore, awayActualScore)
+                  ?.color,
+              }}>
+              {scoreToOwner(homeActualScore, awayActualScore).name}
+            </span>{' '}
+            is leading, but...
+          </h2>
+          {allNextScores(homeActualScore, awayActualScore, scoreToOwner).map(
+            (nextScore, idx) => {
+              if (!nextScore.owner?.name) {
+                return null;
+              }
+
+              const team = nextScore.scorer === 'home' ? homeTeam : awayTeam;
+
+              return (
+                <div key={idx} className="win-conditional">
+                  <div
+                    className="emphasize-name"
+                    style={{ backgroundColor: nextScore.owner.color }}>
+                    {nextScore.owner.name}
+                  </div>
+                  wins if
+                  <div className={`emphasize-name ${team.toLowerCase()}`}>
+                    {team}
+                  </div>
+                  scores a <span className="action-type">{nextScore.type}</span>
+                  <span className={`win-cond-score ${awayTeam.toLowerCase()}`}>
+                    {nextScore.away}
+                  </span>{' '}
+                  -{' '}
+                  <span className={`win-cond-score ${homeTeam.toLowerCase()}`}>
+                    {nextScore.home}
+                  </span>
+                </div>
+              );
+            },
+          )}
+        </>
+      )}
+    </Modal>
+  );
+}


### PR DESCRIPTION

- Made a modal from your modal that you can throw whatever into (makes it easier to needing to pass props too)
- Made the summary pretty parsable
- Put the summary in a modal
- make horrible diffs with my editor double quoting everything

Summary modal:
<img width="719" alt="Screenshot 2024-01-24 at 10 27 49 PM" src="https://github.com/amarcher/superbowl-squares/assets/157326452/6d36cc74-0d36-472f-8ca0-2717358b9992">

Summary button - doesn't steal from the grid size!
<img width="1619" alt="Screenshot 2024-01-24 at 10 33 29 PM" src="https://github.com/amarcher/superbowl-squares/assets/157326452/0bc08ff6-91cd-45e8-b89b-0083910ba69a">
