### PR TITLE
Update the Local Storage Key

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,1 +1,1 @@
-export const LOCAL_STORAGE_KEY = '__superbowl-squares__';
+export const LOCAL_STORAGE_KEY = '_superbowl-squares_';


### PR DESCRIPTION
In the previous PR: https://github.com/amarcher/superbowl-squares/pull/25, I made a breaking change to the app's expectation of the data in local storage (it's much slimmer now), so I need to alter the version the local storage key.

https://react.dev/errors/31?invariant=31&args%5B%5D=object%20with%20keys%20%7Bcolor%2C%20id%7D&args%5B%5D=