### PR TITLE
Fix dynamic route mapping for /api/s/:code

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,12 +1,14 @@
 {
-  "rewrites": [
+  "routes": [
     {
-      "source": "/.well-known/apple-app-site-association",
-      "destination": "/api/aasa"
+      "src": "/.well-known/apple-app-site-association",
+      "dest": "/api/aasa"
     },
     {
-      "source": "/(.*)",
-      "destination": "/index.html"
-    }
+      "src": "/api/s/([^/]+)",
+      "dest": "/api/s/[code].js?code=$1"
+    },
+    { "handle": "filesystem" },
+    { "src": "/(.*)", "dest": "/index.html" }
   ]
 }


### PR DESCRIPTION
## Summary
- Use legacy `routes` with explicit regex mapping for the dynamic `api/s/[code].js` route (same pattern as tabbit-rabbit-reboot)

🤖 Generated with [Claude Code](https://claude.com/claude-code)