### PR TITLE
Update Node.js engine to 24.x

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
 # Trigger rebuild
+.vercel

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "whatwg-fetch": "^3.5.0"
   },
   "engines": {
-    "node": "22.x"
+    "node": "24.x"
   },
   "scripts": {
     "start": "react-scripts start",


### PR DESCRIPTION
## Summary
- Update `engines.node` from `22.x` to `24.x` in package.json to fix Vercel deployment failure
- Add `.vercel` to `.gitignore`

## Test plan
- [ ] Verify Vercel deployment succeeds with Node 24.x

🤖 Generated with [Claude Code](https://claude.com/claude-code)