### PR TITLE
Fix canonical URL trailing slash

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -10,11 +10,11 @@
     <meta name="robots" content="index, follow" />
 
     <!-- Canonical URL -->
-    <link rel="canonical" href="https://superbowl-squares.com" />
+    <link rel="canonical" href="https://superbowl-squares.com/" />
 
     <!-- Open Graph -->
     <meta property="og:type" content="website" />
-    <meta property="og:url" content="https://superbowl-squares.com" />
+    <meta property="og:url" content="https://superbowl-squares.com/" />
     <meta property="og:title" content="Superbowl Squares — Free Online Squares Pool Manager" />
     <meta property="og:description" content="Run your Super Bowl Squares pool for free. Create a grid, assign players, and track the game live." />
     <meta property="og:image" content="https://superbowl-squares.com/og-image.png" />


### PR DESCRIPTION
## Summary
- Adds trailing slash to `canonical` and `og:url` root domain URLs
- Fixes "Duplicate, Google chose different canonical than user" alert in Google Search Console

## Test plan
- [ ] Verify `view-source:https://superbowl-squares.com` shows trailing slash on canonical and og:url after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)